### PR TITLE
freeram => usedram

### DIFF
--- a/qnap_health
+++ b/qnap_health
@@ -52,7 +52,7 @@ usage() {
   echo "       -x|--privprotocol     - privacy protocol (DES|AES)"
   echo "       -X|--privpassphrase   - privacy protocol pass phrase"
   echo
-  echo "Parts are: status, sysinfo, systemuptime, temp, cpu, cputemp, freeram, iops, latency, powerstatus, fans, diskused, hdstatus, hdtemp, lunstatus (for iSCSI luns), volstatus (Raid Volume Status)"
+  echo "Parts are: status, sysinfo, systemuptime, temp, cpu, cputemp, usedram, iops, latency, powerstatus, fans, diskused, hdstatus, hdtemp, lunstatus (for iSCSI luns), volstatus (Raid Volume Status)"
   echo
   echo "volstatus & lunstatus checks all vols/luns and vols/lun space; powerstatus checks power supply"
   echo "<#> is 1-8 for hd, 1-5 for vol"
@@ -399,7 +399,7 @@ elif [ "$strPart" == "cputemp" ]; then
   fi
 
 # Free RAM---------------------------------------------------------------------------------------------------------------------------------------
-elif [ "$strPart" == "freeram" ]; then
+elif [ "$strPart" == "usedram" ]; then
   totalMemStr="$(_snmpgetval 1.3.6.1.4.1.24681.1.2.2.0)"
   freeMemStr="$(_snmpgetval 1.3.6.1.4.1.24681.1.2.3.0)"
 
@@ -431,7 +431,7 @@ elif [ "$strPart" == "freeram" ]; then
     usedMemF="$usedMemH$freeMemUnit"
   fi
 
-  OUTPUT="Total:$totalMemF - Used:$usedMemF - Free:$freeMemF = $percMem%|Memory usage=$percMem%;$strWarning;$strCritical;0;100"
+  OUTPUT="Total:$totalMemF - Used:$usedMemF - Free:$freeMemF|Memory usage=$percMem%;$strWarning;$strCritical;0;100"
 
   if [ $percMem -ge $strCritical ]; then
     echo "CRITICAL: $OUTPUT"


### PR DESCRIPTION
Problem:
- The current code compares warning thresholds for "freeram" with the variable "percMem" which represents used memory in reality.

Fix:
- Rename "freeram" to "usedram" to make it correctly work.